### PR TITLE
ensure rsync is installed

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -39,6 +39,11 @@ class zookeeper::install (
 
   #Install java package
   package { $zookeeper::params::java_package: }
+  
+  #Ensure rsync is installed
+  package { 'rsync':
+    ensure => 'installed',
+  }
 
   #Download and extract the zookeeper archive
   exec { 'zookeeper-get':


### PR DESCRIPTION
some distro or minimal linux system doesn't have rsync installed by default, it would be nice if this module ensure that rsync is going to be installed before `zookeeper-install` executed `rsync` command